### PR TITLE
* Fix - Disabling text for Carousel on Homepage

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 ## Change log
 
+### 1.2.2
+* Fix - Fixing the options for the Team widget, making sure all of them work, also on shortcode mode.
+
 ### 1.2.1 - 19 December 2019
 * Fix - Changing the map priority on the single team pages.
 * Dev - Changing a variable name $ID to $id.

--- a/templates/content-widget-team.php
+++ b/templates/content-widget-team.php
@@ -7,7 +7,7 @@
  * @subpackage	widget
  */
 
-global $disable_placeholder, $disable_text, $post;
+global $disable_placeholder, $disable_text, $post, $disable_view_more;
 
 $member_name = get_the_title();
 
@@ -37,12 +37,21 @@ if ( $has_single ) {
 	</h4>
 
 	<?php
-		if ( empty( $disable_text ) ) {
-			lsx_to_team_role( '<p class="lsx-to-widget-tagline text-center">', '</p>' );
+	if ( empty( $disable_text ) ) {
+		lsx_to_team_role( '<p class="lsx-to-widget-tagline text-center">', '</p>' );
+
+		$member_description = apply_filters( 'the_excerpt', get_the_excerpt() );
+
+		if ( empty( $member_description ) ) {
+			$member_description = apply_filters( 'the_excerpt', wp_trim_words( $post->post_content, 20 ) );
 		}
+
+		$member_description = ! empty( $member_description ) ? "<div class='lsx-team-description'>$member_description</div>" : '';
+		echo wp_kses_post( $member_description );
+	}
 	?>
 
-	<?php if ( $has_single ) { ?>
+	<?php if ( $has_single && empty( $disable_view_more ) ) { ?>
 		<p class="text-center lsx-to-single-link"><a href="<?php echo esc_url( $permalink ); ?>"><?php echo esc_html__( 'More about', 'to-team' ) . ' ' . esc_html( strtok( $member_name, ' ' ) ); ?> <i class="fa fa-angle-right" aria-hidden="true"></i></a></p>
 	<?php } ?>
 </article>


### PR DESCRIPTION
### Description of the Change

This pull request fixes the widget and shortcode options, now it will properly show the excerpt. 

For the shortcode, the excerpt will be enabled by default, but it can be disabled using `disable_text="1"` and the show more link for each team member can be disabled with `disable_view_more="1"`

### Benefits

Proper functioning for the TO team widget and shortcode.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues

https://github.com/lightspeeddevelopment/to-team/issues/3

### Changelog Entry

* Fix - Fixing the options for the Team widget, making sure all of them work, also on shortcode mode.