### PR TITLE
fix: WordPress.org compliance fixes (2.2.0)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,25 @@
 # Change log
 
+## [2.2.0] - 2026-07-29
+
+### Fixed
+- Security: escaped `tel:` and `mailto:` contact links in `lsx_to_team_contact_number()` and `lsx_to_team_contact_email()` template tags using `esc_url()` and `esc_html()`.
+- Security: escaped social profile URLs and icon class with `esc_url()` and `esc_attr()` in `lsx_to_team_social_profiles()`.
+- Security: added `ABSPATH` early-exit guard to all class files, config includes, template tags, and the team-card pattern.
+- Bug: fixed user array population in `config-team.php` — the `$users` array was being overwritten on each iteration instead of appended; `WP_User_Query` is now also scoped to the `team` edit screen to avoid unnecessary queries.
+- Bug: `glob()` call in `LSX_TO_Team_Blocks::register_blocks()` no longer iterates when the directory is empty or does not exist; prevents PHP warnings on fresh installs.
+- Bug: `parse_url()` replaced with `wp_parse_url()` in the contact-link URL normalisation method.
+- Bug: `posts_per_page` for Envira Gallery queries changed from string `'-1'` to integer `-1`.
+- Bug: taxonomy `rewrite` for the `role` taxonomy corrected from `array( 'role' )` to `array( 'slug' => 'role' )`.
+- i18n: `load_plugin_textdomain()` simplified to use WordPress auto-discovery (second and third arguments removed).
+- Code quality: inline `phpcs:ignore` comment updated to the modern `phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.Found` format.
+- Docs: added missing docblocks for `lsx_to_maps_args()` and `lsx_to_has_maps_location()` in `class-to-team-frontend.php`.
+
+### Updated
+- `Requires Plugins: tour-operator` added to plugin header.
+- Version bumped to `2.2.0` in plugin header and `readme.txt`.
+- `readme.txt`: tested up to WordPress 7.0; stable tag updated to `2.2.0`; corrected theme name from "to Theme" to "LSX Theme"; fixed two incomplete FAQ question headings.
+
 ## [[2.2]](https://github.com/lightspeeddevelopment/to-team/releases/tag/2.2) - Unreleased
 
 ### Description

--- a/classes/class-to-team-admin.php
+++ b/classes/class-to-team-admin.php
@@ -9,6 +9,10 @@
  * @copyright 2017 LightSpeedDevelopment
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Main plugin class.
  *

--- a/classes/class-to-team-blocks.php
+++ b/classes/class-to-team-blocks.php
@@ -6,6 +6,11 @@
  * @author    LightSpeed
  * @license   GPL-3.0+
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 class LSX_TO_Team_Blocks {
 
 	/**
@@ -136,7 +141,7 @@ class LSX_TO_Team_Blocks {
 			return 'mailto:' . antispambot( $url );
 		}
 
-		if ( ! parse_url( $url, PHP_URL_SCHEME ) && ! str_starts_with( $url, '//' ) && ! str_starts_with( $url, '#' ) ) {
+		if ( ! wp_parse_url( $url, PHP_URL_SCHEME ) && ! str_starts_with( $url, '//' ) && ! str_starts_with( $url, '#' ) ) {
 			return 'https://' . $url;
 		}
 

--- a/classes/class-to-team-blocks.php
+++ b/classes/class-to-team-blocks.php
@@ -52,7 +52,12 @@ class LSX_TO_Team_Blocks {
 			return;
 		}
 
-		foreach ( glob( $directory . '*', GLOB_ONLYDIR ) as $block_dir ) {
+		$block_dirs = glob( $directory . '*', GLOB_ONLYDIR );
+		if ( empty( $block_dirs ) ) {
+			return;
+		}
+
+		foreach ( $block_dirs as $block_dir ) {
 			register_block_type( $block_dir );
 		}
 	}

--- a/classes/class-to-team-frontend.php
+++ b/classes/class-to-team-frontend.php
@@ -9,6 +9,10 @@
  * @copyright 2017 LightSpeedDevelopment
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Main plugin class.
  *

--- a/classes/class-to-team-frontend.php
+++ b/classes/class-to-team-frontend.php
@@ -71,6 +71,13 @@ class LSX_TO_Team_Frontend {
 		return $orderby;
 	}
 
+	/**
+	 * Filters the map args for team member singles to include connected accommodation.
+	 *
+	 * @param array $args    Current map arguments.
+	 * @param int   $post_id The current post ID.
+	 * @return array
+	 */
 	public function lsx_to_maps_args( $args, $post_id ) {
 		if ( is_singular( 'team' ) ) {
 			$accommodation_connected = get_post_meta( get_the_ID(), 'accommodation_to_team' );
@@ -89,6 +96,13 @@ class LSX_TO_Team_Frontend {
 		return $args;
 	}
 
+	/**
+	 * Filters whether a map location exists for team member singles.
+	 *
+	 * @param array|false $location Current location data or false.
+	 * @param int         $id       The current post ID.
+	 * @return array|false
+	 */
 	public function lsx_to_has_maps_location( $location, $id ) {
 		if ( is_singular( 'team' ) ) {
 			$accommodation_connected = get_post_meta( $id, 'accommodation_to_team' );

--- a/classes/class-to-team-templates.php
+++ b/classes/class-to-team-templates.php
@@ -6,6 +6,10 @@
  * @version 1.0.0
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 class LSX_TO_Team_Templates {
 
 	/**

--- a/classes/class-to-team.php
+++ b/classes/class-to-team.php
@@ -184,7 +184,7 @@ if ( ! class_exists( 'LSX_TO_Team' ) ) {
 		 * Make TO last plugin to load.
 		 */
 		public function activated_plugin() {
-			// @codingStandardsIgnoreLine
+			// phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.Found
 			if ( $plugins = get_option( 'active_plugins' ) ) {
 				$search = preg_grep( '/.*\/tour-operator\.php/', $plugins );
 				$key = array_search( $search, $plugins );

--- a/classes/class-to-team.php
+++ b/classes/class-to-team.php
@@ -9,6 +9,10 @@
  * @copyright {year} LightSpeedDevelopment
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 if ( ! class_exists( 'LSX_TO_Team' ) ) {
 
 	/**
@@ -97,7 +101,7 @@ if ( ! class_exists( 'LSX_TO_Team' ) ) {
 		 * Load the plugin text domain for translation.
 		 */
 		public function load_plugin_textdomain() {
-			load_plugin_textdomain( 'to-team', false, basename( LSX_TO_TEAM_PATH ) . '/languages' );
+			load_plugin_textdomain( 'to-team' );
 		}
 
 		/**

--- a/includes/metaboxes/config-team.php
+++ b/includes/metaboxes/config-team.php
@@ -51,8 +51,8 @@ $users        = array();
 $user_results = $user_query->get_results();
 if ( ! empty( $user_results ) ) {
 	foreach ( $user_results as $user ) {
-		$users = array(
-			'name' => $user->display_name,
+		$users[] = array(
+			'name'  => $user->display_name,
 			'value' => $user->ID,
 		);
 	}

--- a/includes/metaboxes/config-team.php
+++ b/includes/metaboxes/config-team.php
@@ -41,20 +41,22 @@ $metabox['fields'][] = array(
 	'type'	=> 'text',
 );
 
-$user_query = new WP_User_Query(
-	array(
-		'role__not_in' => 'Subscriber',
-	)
-);
-
-$users        = array();
-$user_results = $user_query->get_results();
-if ( ! empty( $user_results ) ) {
-	foreach ( $user_results as $user ) {
-		$users[] = array(
-			'name'  => $user->display_name,
-			'value' => $user->ID,
-		);
+$users          = array();
+$current_screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+if ( $current_screen && 'team' === $current_screen->post_type ) {
+	$user_query   = new WP_User_Query(
+		array(
+			'role__not_in' => 'Subscriber',
+		)
+	);
+	$user_results = $user_query->get_results();
+	if ( ! empty( $user_results ) ) {
+		foreach ( $user_results as $user ) {
+			$users[] = array(
+				'name'  => $user->display_name,
+				'value' => $user->ID,
+			);
+		}
 	}
 }
 

--- a/includes/metaboxes/config-team.php
+++ b/includes/metaboxes/config-team.php
@@ -8,6 +8,11 @@
  * @link
  * @copyright 2017 LightSpeedDevelopment
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 $metabox = array(
 	'title'  => esc_html__( 'Tour Operator Plugin', 'to-team' ),

--- a/includes/metaboxes/config-team.php
+++ b/includes/metaboxes/config-team.php
@@ -155,7 +155,7 @@ if ( class_exists( 'Envira_Gallery' ) ) {
 		'query'      => array(
 			'post_type'      => 'envira',
 			'nopagin'        => true,
-			'posts_per_page' => '-1',
+			'posts_per_page' => -1,
 			'orderby'        => 'title',
 			'order'          => 'ASC',
 		),
@@ -171,7 +171,7 @@ if ( class_exists( 'Envira_Gallery' ) ) {
 			'query'      => array(
 				'post_type'      => 'envira',
 				'nopagin'        => true,
-				'posts_per_page' => '-1',
+				'posts_per_page' => -1,
 				'orderby'        => 'title',
 				'order'          => 'ASC',
 			),

--- a/includes/post-types/config-team.php
+++ b/includes/post-types/config-team.php
@@ -9,6 +9,10 @@
  * @copyright 2017 LightSpeedDevelopment
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 $post_type = array(
 	'class'               => 'LSX_TO_Team',
 	'menu_icon'           => 'dashicons-id-alt',

--- a/includes/taxonomies/config-role.php
+++ b/includes/taxonomies/config-role.php
@@ -33,7 +33,7 @@ $taxonomy = array(
 		'exclude_from_search' => true,
 		'show_admin_column'   => true,
 		'query_var'           => true,
-		'rewrite'             => array( 'role' ),
+		'rewrite'             => array( 'slug' => 'role' ),
 	),
 );
 

--- a/includes/taxonomies/config-role.php
+++ b/includes/taxonomies/config-role.php
@@ -9,6 +9,10 @@
  * @copyright 2017 LightSpeedDevelopment
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 $taxonomy = array(
 	'object_types'  => 'team',
 	'menu_position' => 77,

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -39,7 +39,7 @@ function lsx_to_team_contact_number( $before = '', $after = '', $echo = true ) {
 	$contact_number = get_post_meta( get_the_ID(), 'contact_number', true );
 
 	if ( false !== $contact_number && '' !== $contact_number ) {
-		$contact_html = $before . '<a href="tel:+' . $contact_number . '">' . $contact_number . '</a>' . $after;
+		$contact_html = $before . '<a href="' . esc_url( 'tel:+' . $contact_number ) . '">' . esc_html( $contact_number ) . '</a>' . $after;
 
 		if ( $echo ) {
 			echo wp_kses_post( $contact_html );
@@ -64,7 +64,7 @@ function lsx_to_team_contact_email( $before = '', $after = '', $echo = true ) {
 	$contact_email = get_post_meta( get_the_ID(), 'contact_email', true );
 
 	if ( false !== $contact_email && '' !== $contact_email ) {
-		$contact_html = $before . '<a href="mailto:' . $contact_email . '">' . $contact_email . '</a>' . $after;
+		$contact_html = $before . '<a href="' . esc_url( 'mailto:' . $contact_email ) . '">' . esc_html( $contact_email ) . '</a>' . $after;
 
 		if ( $echo ) {
 			echo wp_kses_post( $contact_html );
@@ -144,7 +144,7 @@ function lsx_to_team_social_profiles( $before = '', $after = '', $echo = true ) 
 				break;
 			}
 
-			$social_profile_html .= '<a target="_blank" rel="noopener noreferrer" href="' . $meta_value . '"><i class="fa fa-' . $icon_class . '" aria-hidden="true"></i></a>';
+			$social_profile_html .= '<a target="_blank" rel="noopener noreferrer" href="' . esc_url( $meta_value ) . '"><i class="fa fa-' . esc_attr( $icon_class ) . '" aria-hidden="true"></i></a>';
 		}
 	}
 

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -9,6 +9,10 @@
  * @copyright 2016 LightSpeedDevelopment
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Outputs the current team members role, must be used in a loop.
  *

--- a/patterns/team-card.php
+++ b/patterns/team-card.php
@@ -14,6 +14,10 @@
 
 // phpcs:ignoreFile PluginCheck.CodeAnalysis.ImageFunctions.NonEnqueuedImage
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 return array(
 	'title'         => __( 'Team Card', 'to-team' ),
 	'description'   => __( 'A card layout for displaying team members in query loops with photo, role, tagline, contact details and social links.', 'to-team' ),

--- a/readme.txt
+++ b/readme.txt
@@ -17,8 +17,8 @@ People like to see a face behind a business, it gives you a more personal, appro
 
 The Tour Operator Team plugin allows you to display your team profiles beautifully on your website. 
 
-= Works with the to Theme =
-Our theme [theme](https://lsx.design/) works perfectly with the Team Extension, improving internal linking, website SEO and user experience! 
+= Works with the LSX Theme =
+The [LSX Theme](https://lsx.design/) works perfectly with the Team Extension, improving internal linking, website SEO and user experience! 
 
 = It's free, and always will be. =
 We’re firm believers in open source - that’s why we’re releasing the Tour Operator Team plugin for free, forever. 

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: feedmymedia, lightspeedwp, eleshar, krugazul
 Donate link: https://lightspeedwp.agency/donate/
 Tags: lsx, tour operator, team, team members, our team
 Requires at least: 6.7
-Tested up to: 6.9
+Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 2.2
+Stable tag: 2.2.0
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
 
@@ -42,11 +42,11 @@ After you have downloaded the Tour Operator Team extension from WordPress.org:
 = Where can I find Tour Operator Team plugin documentation and user guides? =
 For help setting up and configuring the Team plugin please refer to our [user guide](https://touroperator.solutions/docs/team/)
 
-= Where can I get support or talk to other users =
+= Where can I get support or talk to other users? =
 
 Contact the [LightSpeed](https://lightspeedwp.agency/) for assistance via the [LSX support form](https://lightspeedwp.agency/lsx/support/).
 
-= Will the Tour Operator Team plugin work with my theme 
+= Will the Tour Operator Team plugin work with my theme? =
 Yes; the Tour Operator Team plugin will work with any theme, but may require some styling to make it match nicely. Please see our [codex](https://touroperator.solutions/docs/) for help.
 
 = Where can I report bugs or contribute to the project? =
@@ -62,11 +62,9 @@ Yes you can! Join in on our [GitHub repository](https://github.com/lightspeeddev
 3. Tour Operator Team Widget
 4. LSX The Settings Panel for to Team
 
-== Screenshots ==
-
 == Changelog ==
 
-= 2.2 =
+= 2.2.0 =
 * Added Gutenberg block variations: featured team, related team members, post meta blocks (tagline, role, contact email, contact number, social links), post connection blocks (to accommodation, destination, tour), and gallery block.
 * Added related blocks for destination, accommodation, and tour post types.
 * Migrated build tooling from Gulp to wp-scripts.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: feedmymedia, lightspeedwp, eleshar, krugazul
 Donate link: https://lightspeedwp.agency/donate/
 Tags: lsx, tour operator, team, team members, our team
 Requires at least: 6.7
-Tested up to: 6.7
+Tested up to: 7.0
 Requires PHP: 8.0
 Stable tag: 2.2.0
 License: GPLv3 or later

--- a/to-team.php
+++ b/to-team.php
@@ -3,13 +3,14 @@
  * Plugin Name:	Tour Operator Team
  * Plugin URI:	https://touroperator.solutions/plugins/team/
  * Description:	Real peoples' faces go a long way to building trust with your clients. The Team Extension allows your business's staff to be added as Team Members with their own profile which can be associated with specific destinations and tours.
- * Version:     2.2
+ * Version:     2.2.0
  * Author:      LightSpeed
  * Author URI: 	https://lightspeedwp.agency/
  * License: 	GPL3+
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  * Text Domain: to-team
  * Domain Path: /languages/
+ * Requires Plugins: tour-operator
  */
 
 // If this file is called directly, abort.


### PR DESCRIPTION
## Summary

WordPress.org plugin review compliance fixes: security hardening, bug fixes, and code quality improvements. Bumps the version to `2.2.0`.

## Changes

### Security
- Escaped `tel:` and `mailto:` contact links in `lsx_to_team_contact_number()` and `lsx_to_team_contact_email()` using `esc_url()` and `esc_html()`.
- Escaped social profile URLs and icon classes with `esc_url()` and `esc_attr()` in `lsx_to_team_social_profiles()`.
- Added `ABSPATH` early-exit guard to all class files, config includes, template tags, and the team-card pattern.

### Fixed
- **User array population** — `$users` was being overwritten (`=` instead of `[]`) on each loop iteration; corrected to `$users[]`. `WP_User_Query` is now also scoped to the `team` edit screen to avoid firing on every admin page load.
- **`glob()` guard** — `LSX_TO_Team_Blocks::register_blocks()` now returns early when the block directory is empty or does not exist, preventing PHP warnings on fresh installs.
- **`wp_parse_url()`** — replaced native `parse_url()` with the WordPress wrapper.
- **`posts_per_page` type** — Envira Gallery queries now use integer `-1` instead of string `'-1'`.
- **Taxonomy rewrite** — `role` taxonomy rewrite corrected from `array( 'role' )` to `array( 'slug' => 'role' )`.

### Updated
- `load_plugin_textdomain()` simplified to WordPress auto-discovery (removed deprecated path arguments).
- Inline `@codingStandardsIgnoreLine` updated to `phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.Found`.
- `Requires Plugins: tour-operator` added to plugin header.
- Version bumped to `2.2.0` in plugin header and `readme.txt`.
- `readme.txt`: tested up to WordPress 7.0; stable tag `2.2.0`; corrected theme name to "LSX Theme"; fixed two incomplete FAQ headings.

### Docs
- Added missing docblocks for `lsx_to_maps_args()` and `lsx_to_has_maps_location()`.

## Testing

- [ ] Team member contact number and email links render correctly and are properly escaped.
- [ ] Social profile links render with correct URLs and icon classes.
- [ ] Plugin activates cleanly on a fresh install (no PHP warnings from `glob()`).
- [ ] User select field in team metabox populates correctly on the team edit screen.
- [ ] `Role` taxonomy slugs rewrite correctly in URLs.
- [ ] No regressions on existing team member archive and single templates.

## Checklist

- [x] Changelog updated (`2.2.0` entry added)
- [x] No new features introduced — fixes only
- [x] `Requires Plugins` header added for wp.org compatibility