### PR TITLE
fix(schema): align Team Person schema with Schema 2.0 mapping

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,20 @@
 # Change log
 
+## [2.2 — Schema] - 2026-07-29
+
+### Fixed
+- Schema: `@type` simplified from a single-item array to a plain `'Person'` string.
+- Schema: `@id` updated from `#person` to `#/schema/person/{id}` to avoid collisions on multi-person pages.
+- Schema: `name` now uses `get_the_title( $post->ID )` instead of `$post->post_title` directly.
+- Schema: `description` now uses `\lsx\schema\Helpers::strip_to_text()` on `apply_filters( 'the_content', … )` instead of a bare `wp_strip_all_tags()` on raw post content.
+- Schema: removed duplicate `memberOf` property (same reference as `worksFor`); `worksFor` is retained.
+- Schema: replaced the semantically incorrect `owns` property with `additionalProperty` `PropertyValue` entries via a new `add_associated_property()` helper — connected tours listed as "Associated Tours", connected accommodation as "Associated Accommodation".
+- Schema: `add_products()` renamed to `add_associated_products()` to reflect the corrected output type.
+
+### Added
+- Schema: new `add_same_as()` method that reads `facebook`, `twitter`, `googleplus`, `linkedin`, and `pinterest` custom fields and outputs them as a `sameAs` array on the `Person` node.
+- Schema: new `add_associated_property()` helper that builds a single `additionalProperty` `PropertyValue` from a list of related post IDs.
+
 ## [[2.2]](https://github.com/lightspeeddevelopment/to-team/releases/tag/2.2) - Unreleased
 
 ### Description

--- a/classes/class-to-team-schema.php
+++ b/classes/class-to-team-schema.php
@@ -32,7 +32,7 @@ class LSX_TO_Team_Schema extends LSX_TO_Schema_Graph_Piece {
 			'@type'            => 'Person',
 			'@id'              => $this->context->canonical . '#/schema/person/' . $this->post->ID,
 			'name'             => get_the_title( $this->post->ID ),
-			'description'      => wp_strip_all_tags( apply_filters( 'the_content', $this->post->post_content ) ),
+			'description'      => \lsx\schema\Helpers::strip_to_text( apply_filters( 'the_content', $this->post->post_content ) ),
 			'url'              => $this->post_url,
 			'mainEntityOfPage' => array(
 				'@id' => $this->context->canonical . WPSEO_Schema_IDs::WEBPAGE_HASH,

--- a/classes/class-to-team-schema.php
+++ b/classes/class-to-team-schema.php
@@ -6,7 +6,7 @@
  */
 
 /**
- * Returns schema Review data.
+ * Returns schema Person data for Team posts.
  *
  * @since 10.2
  */
@@ -23,18 +23,16 @@ class LSX_TO_Team_Schema extends LSX_TO_Schema_Graph_Piece {
 	}
 
 	/**
-	 * Returns Review data.
+	 * Returns Person data.
 	 *
-	 * @return array $data Review data.
+	 * @return array $data Person data.
 	 */
 	public function generate() {
 		$data = array(
-			'@type'            => array(
-				'Person',
-			),
-			'@id'              => $this->context->canonical . '#person',
-			'name'             => $this->post->post_title,
-			'description'      => wp_strip_all_tags( $this->post->post_content ),
+			'@type'            => 'Person',
+			'@id'              => $this->context->canonical . '#/schema/person/' . $this->post->ID,
+			'name'             => get_the_title( $this->post->ID ),
+			'description'      => wp_strip_all_tags( apply_filters( 'the_content', $this->post->post_content ) ),
 			'url'              => $this->post_url,
 			'mainEntityOfPage' => array(
 				'@id' => $this->context->canonical . WPSEO_Schema_IDs::WEBPAGE_HASH,
@@ -43,31 +41,86 @@ class LSX_TO_Team_Schema extends LSX_TO_Schema_Graph_Piece {
 
 		if ( $this->context->site_represents_reference ) {
 			$data['worksFor'] = $this->context->site_represents_reference;
-			$data['memberOf'] = $this->context->site_represents_reference;
 		}
 
 		$data = $this->add_taxonomy_terms( $data, 'jobTitle', 'role' );
 		$data = $this->add_custom_field( $data, 'email', 'contact_email' );
 		$data = $this->add_custom_field( $data, 'telephone', 'contact_number' );
-		$data = $this->add_products( $data );
+		$data = $this->add_same_as( $data );
+		$data = $this->add_associated_products( $data );
 		$data = $this->add_offers( $data, 'makesOffer' );
 		$data = \lsx\legacy\Schema_Utils::add_image( $data, $this->context );
 		return $data;
 	}
 
 	/**
-	 * Adds the accommodation and tour products under the 'owns' parameter
+	 * Adds the sameAs entries for any populated social profile fields.
 	 *
-	 * @param array $data
-	 * @return array
+	 * @param array $data Person data.
+	 * @return array $data Person data.
 	 */
-	public function add_products( $data ) {
-		$places_array = array();
-		$places_array = $this->add_accommodation( $places_array );
-		$places_array = $this->add_tours( $places_array );
-		if ( ! empty( $places_array ) ) {
-			$data['owns'] = $places_array;
+	public function add_same_as( $data ) {
+		$social_fields = array( 'facebook', 'twitter', 'googleplus', 'linkedin', 'pinterest' );
+		$same_as       = array();
+
+		foreach ( $social_fields as $social_field ) {
+			$value = get_post_meta( $this->context->id, $social_field, true );
+			if ( false !== $value && '' !== $value ) {
+				$same_as[] = $value;
+			}
 		}
+
+		if ( ! empty( $same_as ) ) {
+			$data['sameAs'] = $same_as;
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Adds the associated tours and accommodation as additionalProperty values,
+	 * replacing the previous semantically incorrect 'owns' output.
+	 *
+	 * @param array $data Person data.
+	 * @return array $data Person data.
+	 */
+	public function add_associated_products( $data ) {
+		$data = $this->add_associated_property( $data, 'accommodation_to_' . $this->post_type, __( 'Associated Accommodation', 'to-team' ) );
+		$data = $this->add_associated_property( $data, 'tour_to_' . $this->post_type, __( 'Associated Tours', 'to-team' ) );
+		return $data;
+	}
+
+	/**
+	 * Builds a single additionalProperty entry from a list of related post IDs.
+	 *
+	 * @param array  $data     Person data.
+	 * @param string $meta_key The meta key storing the related post IDs.
+	 * @param string $label    The additionalProperty name/label.
+	 * @return array $data Person data.
+	 */
+	public function add_associated_property( $data, $meta_key, $label ) {
+		$ids    = get_post_meta( $this->context->id, $meta_key, false );
+		$titles = array();
+
+		if ( ! empty( $ids ) ) {
+			foreach ( $ids as $id ) {
+				if ( '' !== $id ) {
+					$title = get_the_title( $id );
+					if ( '' !== $title ) {
+						$titles[] = $title;
+					}
+				}
+			}
+		}
+
+		if ( ! empty( $titles ) ) {
+			$data['additionalProperty'][] = array(
+				'@type' => 'PropertyValue',
+				'name'  => $label,
+				'value' => implode( ', ', $titles ),
+			);
+		}
+
 		return $data;
 	}
 }


### PR DESCRIPTION
## Summary

Aligns `class-to-team-schema.php` with the approved Schema 2.0 mapping and shared helpers. All changes are confined to the single schema class.

## Changes

### Fixed
- **`@type`** simplified from `array( 'Person' )` to a plain `'Person'` string.
- **`@id`** updated from `#person` to `#/schema/person/{id}` to avoid collisions on multi-person pages.
- **`name`** now uses `get_the_title( $post->ID )` instead of `$post->post_title` directly.
- **`description`** now uses `\lsx\schema\Helpers::strip_to_text()` on `apply_filters( 'the_content', … )` instead of a bare `wp_strip_all_tags()` on raw post content.
- **`memberOf` removed** — was a duplicate of `worksFor` pointing to the same site reference.
- **`owns` replaced** with `additionalProperty` `PropertyValue` entries via a new `add_associated_property()` helper: connected tours output as "Associated Tours", connected accommodation as "Associated Accommodation". `Person` does not semantically own tours or accommodation.
- **`add_products()` renamed** to `add_associated_products()` to reflect the corrected output.

### Added
- **`add_same_as()`** — new method that reads `facebook`, `twitter`, `googleplus`, `linkedin`, and `pinterest` custom fields and outputs populated values as a `sameAs` array on the `Person` node.
- **`add_associated_property()`** — new helper that builds a single `additionalProperty` `PropertyValue` from a list of related post IDs.

## Testing

- [ ] Team member with social profiles — confirm `sameAs` array appears in schema output with correct URLs.
- [ ] Team member with connected tours and accommodation — confirm `additionalProperty` entries appear (not `owns`).
- [ ] Team member with no social profiles — confirm `sameAs` is absent from output.
- [ ] Confirm `@id` is unique per team member page.
- [ ] Validate output with Google Rich Results Test or Schema.org validator.

## Checklist

- [x] Changelog updated
- [x] No new dependencies introduced
- [x] Follows `\lsx\schema\Helpers` shared helper conventions
- [x] `memberOf` duplicate removed